### PR TITLE
Enforce "reasonable" upper bound on generated password length

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -10,11 +10,13 @@ var (
 	defaultPwLen = 24
 )
 
-// Generate will return a securely generated password. It uses the environment
-// variable PASSGO_GENERATE_PASSWORD_LENGTH to determine the length, otherwise
-// it defaults to 24 characters long.
+// Generate will return a securely generated password.
+// A default password length of 24 with be used if
+//     1. No pwlen is supplied
+//     2. pwlen is less than 1
+//     3. pwlen is greater than 2^17(131,072)
 func Generate(pwlen int) string {
-	if pwlen < 1 {
+	if pwlen < 1 || pwlen > 1<<17 {
 		pwlen = defaultPwLen
 	}
 	// By default, we should generate a strog password that needs everything


### PR DESCRIPTION
Summary of PR:
1. Use default password length of 24 if a password of length > 1024 is requested, though I am sure this is still too high in practice since most services won't have a limit this high
2. Remove misleading comment about environment variable PASSGO_GENERATE_PASSWORD_LENGTH, which does not appear to be referenced anywhere