### PR TITLE
Fixes password generation algorithm to ensure the password length is as specified

### DIFF
--- a/pc/pc.go
+++ b/pc/pc.go
@@ -219,8 +219,8 @@ func GeneratePassword(specs *PasswordSpecs, passlen int) (pass string, err error
 			}
 			// Check to make sure that the letter is inside
 			// the range of printable characters
-			if letter > 32 && letter < 127 {
-				pass += string(letter)
+			if letr := string(letter); letter > 32 && letter < 127 && (len(letr) + len(pass) <= passlen)  {
+				pass += letr
 			}
 			updateSpec(specs, letter)
 		}


### PR DESCRIPTION
After using the password generation function for a while I noticed that sometimes the length would be totally off from what I had specified as an argument. I managed to track the problem and found that using `string(letter)` sometimes created a string consisting of multiple characters, not just 1. I figure this is because of UTF-8, but I'm not sure.

This simple fix makes sure the generated password is always of the length specified.
