### PR TITLE
Add unit tests for generate/generate.go

### DIFF
--- a/generate/generate.go
+++ b/generate/generate.go
@@ -15,10 +15,13 @@ var (
 //     1. No pwlen is supplied
 //     2. pwlen is less than 1
 //     3. pwlen is greater than 2^17(131,072)
+// NOTE: passwords are only guaranteed to be *at least* pwlen in length
+//       they may in fact be longer
 func Generate(pwlen int) string {
 	if pwlen < 1 || pwlen > 1<<17 {
 		pwlen = defaultPwLen
 	}
+
 	// By default, we should generate a strog password that needs everything
 	specs := &pc.PasswordSpecs{
 		NeedsUpper:  true,

--- a/generate/generate_test.go
+++ b/generate/generate_test.go
@@ -1,0 +1,31 @@
+package generate;
+
+import (
+	"testing"
+	"unicode/utf8"
+	
+	"github.com/ejcx/passgo/generate"
+)
+
+var generateTests = []struct {
+  n        int // input
+  expected int // expected result
+}{
+  {0,       24},
+  {-1,      24},
+  {5,        5},
+  {10,      10},
+  {1<<18,   24},
+  {1<<32-1, 24},
+}
+
+func TestGenerate(t *testing.T) {
+	for _, tt := range generateTests {
+		actual := generate.Generate(tt.n)
+		actual_length := utf8.RuneCountInString(actual)
+
+		if actual_length < tt.expected {
+			t.Errorf("Generate(%d): expected >= %d, actual %d", tt.n, tt.expected, actual_length)
+		}
+	}
+}


### PR DESCRIPTION
Partially completes #6 by adding unit tests for the generate package. These unit tests verify that given a pwlen = N you get a generated password that is at least length N. Uses the utf8.RuneCountInString so it should be safe on multi-byte characters.

You can verify that is passes by running:

    go test -v generate/generate_test.go