### PR TITLE
Add copy to clipboard option. Minor refactoring.

### DIFF
--- a/pio/pio.go
+++ b/pio/pio.go
@@ -11,6 +11,8 @@ import (
 	"os/user"
 	"path/filepath"
 
+	"github.com/atotto/clipboard"
+
 	"golang.org/x/crypto/ssh/terminal"
 )
 
@@ -283,5 +285,11 @@ func CheckAttackFile() {
 	}
 	if _, err := os.Stat(fn); err == nil {
 		log.Fatalf("You are under attack. Remove file %s to proceed.", fn)
+	}
+}
+
+func ToClipboard(s string) {
+	if err := clipboard.WriteAll(s); err != nil {
+		log.Fatalf("Could not copy password to clipboard: %s", err.Error())
 	}
 }

--- a/show/show.go
+++ b/show/show.go
@@ -62,14 +62,14 @@ func Find(frag string) {
 }
 
 // Site will print out the password of the site that matches path
-func Site(path string) {
+func Site(path string, copyPassword bool) {
 	allSites, allErrors := SearchAll(One, path)
 	if len(allSites) == 0 {
 		fmt.Printf("Site with path %s not found", path)
 		return
 	}
 	masterPrivKey := pc.GetMasterKey()
-	showPassword(allSites, masterPrivKey)
+	showPassword(allSites, masterPrivKey, copyPassword)
 	handleErrors(allErrors)
 }
 
@@ -80,7 +80,7 @@ func ListAll() {
 	handleErrors(allErrors)
 }
 
-func showPassword(allSites map[string][]pio.SiteInfo, masterPrivKey [32]byte) {
+func showPassword(allSites map[string][]pio.SiteInfo, masterPrivKey [32]byte, copyPassword bool) {
 	for _, siteList := range allSites {
 		for _, site := range siteList {
 			sitePassword, err := pc.OpenAsym(site.PassSealed, &site.PubKey, &masterPrivKey)
@@ -88,7 +88,11 @@ func showPassword(allSites map[string][]pio.SiteInfo, masterPrivKey [32]byte) {
 				log.Println("Could not decrypt site password.")
 				continue
 			}
-			fmt.Println(string(sitePassword))
+			if copyPassword {
+				pio.ToClipboard(string(sitePassword))
+			} else {
+				fmt.Println(string(sitePassword))
+			}
 		}
 	}
 }

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -126,7 +126,9 @@ func Clone(repo string) {
 	if err != nil {
 		log.Fatalf("Could not clone repo: %s", err.Error())
 	}
+	Remote(repo)
 	verifyIntegrity()
+
 }
 
 // InsertCommit is used to create a new commit with an insert message.

--- a/vendor/github.com/atotto/clipboard/LICENSE
+++ b/vendor/github.com/atotto/clipboard/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2013 Ato Araki. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of @atotto. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/github.com/atotto/clipboard/README.md
+++ b/vendor/github.com/atotto/clipboard/README.md
@@ -1,0 +1,50 @@
+[![Build Status](https://travis-ci.org/atotto/clipboard.svg?branch=master)](https://travis-ci.org/atotto/clipboard) [![Build Status](https://drone.io/github.com/atotto/clipboard/status.png)](https://drone.io/github.com/atotto/clipboard/latest) 
+
+[![GoDoc](https://godoc.org/github.com/atotto/clipboard?status.svg)](http://godoc.org/github.com/atotto/clipboard)
+
+# Clipboard for Go
+
+Provide copying and pasting to the Clipboard for Go.
+
+Download shell commands at https://drone.io/github.com/atotto/clipboard/files
+
+Build:
+
+    $ go get github.com/atotto/clipboard
+
+Platforms:
+
+* OSX
+* Windows 7 (probably work on other Windows)
+* Linux, Unix (requires 'xclip' or 'xsel' command to be installed)
+
+
+Document: 
+
+* http://godoc.org/github.com/atotto/clipboard
+
+Notes:
+
+* Text string only
+* UTF-8 text encoding only (no conversion)
+
+TODO:
+
+* Clipboard watcher(?)
+
+## Commands:
+
+paste shell command:
+
+    $ go get github.com/atotto/clipboard/cmd/gopaste
+    $ # example:
+    $ gopaste > document.txt
+
+copy shell command:
+
+    $ go get github.com/atotto/clipboard/cmd/gocopy
+    $ # example:
+    $ cat document.txt | gocopy
+
+
+

--- a/vendor/github.com/atotto/clipboard/clipboard.go
+++ b/vendor/github.com/atotto/clipboard/clipboard.go
@@ -1,0 +1,22 @@
+// Copyright 2013 @atotto. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package clipboard read/write on clipboard
+package clipboard
+
+import ()
+
+// ReadAll read string from clipboard
+func ReadAll() (string, error) {
+	return readAll()
+}
+
+// WriteAll write string to clipboard
+func WriteAll(text string) error {
+	return writeAll(text)
+}
+
+// Unsupported might be set true during clipboard init, to help callers decide
+// whether or not to offer clipboard options.
+var Unsupported bool

--- a/vendor/github.com/atotto/clipboard/clipboard_darwin.go
+++ b/vendor/github.com/atotto/clipboard/clipboard_darwin.go
@@ -1,0 +1,52 @@
+// Copyright 2013 @atotto. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build darwin
+
+package clipboard
+
+import (
+	"os/exec"
+)
+
+var (
+	pasteCmdArgs = "pbpaste"
+	copyCmdArgs  = "pbcopy"
+)
+
+func getPasteCommand() *exec.Cmd {
+	return exec.Command(pasteCmdArgs)
+}
+
+func getCopyCommand() *exec.Cmd {
+	return exec.Command(copyCmdArgs)
+}
+
+func readAll() (string, error) {
+	pasteCmd := getPasteCommand()
+	out, err := pasteCmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+func writeAll(text string) error {
+	copyCmd := getCopyCommand()
+	in, err := copyCmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+
+	if err := copyCmd.Start(); err != nil {
+		return err
+	}
+	if _, err := in.Write([]byte(text)); err != nil {
+		return err
+	}
+	if err := in.Close(); err != nil {
+		return err
+	}
+	return copyCmd.Wait()
+}

--- a/vendor/github.com/atotto/clipboard/clipboard_unix.go
+++ b/vendor/github.com/atotto/clipboard/clipboard_unix.go
@@ -1,0 +1,90 @@
+// Copyright 2013 @atotto. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build freebsd linux netbsd openbsd solaris
+
+package clipboard
+
+import (
+	"errors"
+	"os/exec"
+)
+
+const (
+	xsel  = "xsel"
+	xclip = "xclip"
+)
+
+var (
+	pasteCmdArgs []string
+	copyCmdArgs  []string
+
+	xselPasteArgs = []string{xsel, "--output", "--clipboard"}
+	xselCopyArgs  = []string{xsel, "--input", "--clipboard"}
+
+	xclipPasteArgs = []string{xclip, "-out", "-selection", "clipboard"}
+	xclipCopyArgs  = []string{xclip, "-in", "-selection", "clipboard"}
+
+	missingCommands = errors.New("No clipboard utilities available. Please install xsel or xclip.")
+)
+
+func init() {
+	pasteCmdArgs = xclipPasteArgs
+	copyCmdArgs = xclipCopyArgs
+
+	if _, err := exec.LookPath(xclip); err == nil {
+		return
+	}
+
+	pasteCmdArgs = xselPasteArgs
+	copyCmdArgs = xselCopyArgs
+
+	if _, err := exec.LookPath(xsel); err == nil {
+		return
+	}
+
+	Unsupported = true
+}
+
+func getPasteCommand() *exec.Cmd {
+	return exec.Command(pasteCmdArgs[0], pasteCmdArgs[1:]...)
+}
+
+func getCopyCommand() *exec.Cmd {
+	return exec.Command(copyCmdArgs[0], copyCmdArgs[1:]...)
+}
+
+func readAll() (string, error) {
+	if Unsupported {
+		return "", missingCommands
+	}
+	pasteCmd := getPasteCommand()
+	out, err := pasteCmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+func writeAll(text string) error {
+	if Unsupported {
+		return missingCommands
+	}
+	copyCmd := getCopyCommand()
+	in, err := copyCmd.StdinPipe()
+	if err != nil {
+		return err
+	}
+
+	if err := copyCmd.Start(); err != nil {
+		return err
+	}
+	if _, err := in.Write([]byte(text)); err != nil {
+		return err
+	}
+	if err := in.Close(); err != nil {
+		return err
+	}
+	return copyCmd.Wait()
+}

--- a/vendor/github.com/atotto/clipboard/clipboard_windows.go
+++ b/vendor/github.com/atotto/clipboard/clipboard_windows.go
@@ -1,0 +1,101 @@
+// Copyright 2013 @atotto. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// +build windows
+
+package clipboard
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+const (
+	cfUnicodetext = 13
+	gmemFixed     = 0x0000
+)
+
+var (
+	user32           = syscall.MustLoadDLL("user32")
+	openClipboard    = user32.MustFindProc("OpenClipboard")
+	closeClipboard   = user32.MustFindProc("CloseClipboard")
+	emptyClipboard   = user32.MustFindProc("EmptyClipboard")
+	getClipboardData = user32.MustFindProc("GetClipboardData")
+	setClipboardData = user32.MustFindProc("SetClipboardData")
+
+	kernel32     = syscall.NewLazyDLL("kernel32")
+	globalAlloc  = kernel32.NewProc("GlobalAlloc")
+	globalFree   = kernel32.NewProc("GlobalFree")
+	globalLock   = kernel32.NewProc("GlobalLock")
+	globalUnlock = kernel32.NewProc("GlobalUnlock")
+	lstrcpy      = kernel32.NewProc("lstrcpyW")
+)
+
+func readAll() (string, error) {
+	r, _, err := openClipboard.Call(0)
+	if r == 0 {
+		return "", err
+	}
+	defer closeClipboard.Call()
+
+	h, _, err := getClipboardData.Call(cfUnicodetext)
+	if r == 0 {
+		return "", err
+	}
+
+	l, _, err := globalLock.Call(h)
+	if l == 0 {
+		return "", err
+	}
+
+	text := syscall.UTF16ToString((*[1 << 20]uint16)(unsafe.Pointer(l))[:])
+
+	r, _, err = globalUnlock.Call(h)
+	if r == 0 {
+		return "", err
+	}
+
+	return text, nil
+}
+
+func writeAll(text string) error {
+	r, _, err := openClipboard.Call(0)
+	if r == 0 {
+		return err
+	}
+	defer closeClipboard.Call()
+
+	r, _, err = emptyClipboard.Call(0)
+	if r == 0 {
+		return err
+	}
+
+	data := syscall.StringToUTF16(text)
+
+	h, _, err := globalAlloc.Call(gmemFixed, uintptr(len(data)*int(unsafe.Sizeof(data[0]))))
+	if h == 0 {
+		return err
+	}
+
+	l, _, err := globalLock.Call(h)
+	if l == 0 {
+		return err
+	}
+
+	r, _, err = lstrcpy.Call(l, uintptr(unsafe.Pointer(&data[0])))
+	if r == 0 {
+		return err
+	}
+
+	r, _, err = globalUnlock.Call(h)
+	if r == 0 {
+		return err
+	}
+
+	r, _, err = setClipboardData.Call(cfUnicodetext, h)
+	if r == 0 {
+		return err
+	}
+	return nil
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -24,6 +24,12 @@
 			"revision": "1f22c0103821b9390939b6776727195525381532"
 		},
 		{
+			"checksumSHA1": "SNSgdp5ShDZ57VZqBkQ0PXJCJIM=",
+			"path": "github.com/atotto/clipboard",
+			"revision": "bb272b845f1112e10117e3e45ce39f690c0001ad",
+			"revisionTime": "2016-02-19T12:44:21+09:00"
+		},
+		{
 			"checksumSHA1": "hl0ImqBoUBVNVmz5ImX6YVBV9JU=",
 			"path": "golang.org/x/crypto/nacl/box",
 			"revision": "c197bcf24cde29d3f73c7b4ac6fd41f4384e8af6",


### PR DESCRIPTION
Use flag args. Using os.Args will become increasingly
complex as more and more command line flags get added.