### PR TITLE
Deletes all sites if no argument specified for 'passgo remove'.

### DIFF
--- a/edit/edit.go
+++ b/edit/edit.go
@@ -21,6 +21,10 @@ import (
 
 // Remove is used to remove a site entry from the password vault given a path.
 func Remove(path string) {
+	if path == "" {
+		removeAll()
+		return
+	}
 	vault := pio.GetVault()
 	pathIndex := -1
 	for jj, siteInfo := range vault {
@@ -38,6 +42,24 @@ func Remove(path string) {
 		log.Fatalf("Could not update password vault: %s", err.Error())
 	}
 	sync.RemoveCommit(path)
+}
+
+func removeAll() {
+	certain, err := pio.PromptYesNo("Delete all sites?", false)
+	if !certain || err != nil {
+		return
+	}
+
+	vault := pio.GetVault()
+	for i := len(vault); i > 0; i-- {
+		vault, vault[len(vault)-1] = append(vault[:0], vault[1:]...), *new(pio.SiteInfo)
+	}
+	err = pio.UpdateVault(vault)
+	if err != nil {
+		log.Fatalf("Could not update password vault: %s", err.Error())
+	}
+	sync.RemoveAllCommit()
+	fmt.Println("All sites have been deleted")
 }
 
 // Edit is used to change the password of a site. New keys MUST be generated.

--- a/pio/pio.go
+++ b/pio/pio.go
@@ -10,6 +10,7 @@ import (
 	"os"
 	"os/user"
 	"path/filepath"
+	"strings"
 
 	"golang.org/x/crypto/ssh/terminal"
 )
@@ -253,6 +254,25 @@ func Prompt(prompt string) (s string, err error) {
 	stdin := bufio.NewReader(os.Stdin)
 	l, _, err := stdin.ReadLine()
 	return string(l), err
+}
+
+func PromptYesNo(prompt string, defaultYes bool) (ans bool, err error) {
+	a := ""
+	if defaultYes {
+		a, err = Prompt(prompt + " [Y/n]: ")
+	} else {
+		a, err = Prompt(prompt + " [y/N]: ")
+	}
+	switch strings.TrimSpace(strings.ToLower(a)) {
+		case "y", "yes", "true":
+			return true, err
+		case "n", "no", "false":
+			return false, err
+		case "":
+			return defaultYes, err
+		default:
+			return PromptYesNo(prompt, defaultYes)
+	}
 }
 
 // GetAttackFileName returns the full path of the attack file.

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -144,6 +144,11 @@ func RemoveCommit(name string) {
 	Commit(fmt.Sprintf("Removed site %s", name))
 }
 
+// RemoveAllCommit is used to create a new commit with a removed all commit message
+func RemoveAllCommit() {
+	Commit(fmt.Sprintf("Removed all sites"))
+}
+
 // RegenerateCommit is used to create a new commit with a regenerate message.
 func RegenerateCommit(name string) {
 	Commit(fmt.Sprintf("Regenerated password for site %s", name))


### PR DESCRIPTION
This is a pretty simple but nice feature that I think could come to use. It might not be used very often, or at all by some users - but if you need the functionality to delete all your sites it would be extremely tedious without this feature. 

It's pretty simple. If passing `passgo remove` without any arguments the user will get a confirmation prompt and then all sites will be deleted.
