### PR TITLE
Add support for encrypted files. Fix -copy bug.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 [![Build Status](https://travis-ci.org/ejcx/passgo.svg?branch=master)](https://travis-ci.org/ejcx/passgo)
 # passgo
-stores, retrieves, generates, and synchronizes passwords securely and is written in Go! It is inspired by https://passwordstore.org but has a few key differences. The most important difference is passgo is not GPG based. Instead it uses a master password to securely store your passwords.
+stores, retrieves, generates, and synchronizes passwords and files securely and is written in Go! It is inspired by https://passwordstore.org but has a few key differences. The most important difference is passgo is not GPG based. Instead it uses a master password to securely store your passwords. It also supports encrypting arbitrary files.
 
-passgo is meant to be secure enough that you can publicly post your password vault. I've started publishing my passwords [here](https://github.com/ejcx/passwords.git).
+passgo is meant to be secure enough that you can publicly post your vault. I've started publishing my passwords [here](https://github.com/ejcx/passwords.git).
 
 ## Getting started with passgo
 
@@ -64,6 +64,13 @@ Here we are adding mint.com to the password store, but more specifically to the 
 
 ```
 $ passgo insert mney/mint.com
+```
+
+#### passgo insertfile group/file-name filepath
+Adding a file works almost the same as insert. Instead it has an extra argument. The file that you want to add to your vault is the final argument. Grouping works the same way with `insertfile` as `insert`.
+
+```
+$ passgo insertfile money/moneyfile.txt expenses.txt
 ```
 
 #### passgo show group/pass-name
@@ -129,6 +136,13 @@ $ passgo
 |  └──somethingelse.com
 └──twiinsen.com
    └──bbbbb
+```
+
+#### passgo removefile group/file-name
+removefile is used for removing files from the password vault. `passgo rmfile` is an alias of `passgo removefile`. removefile works the same way as remoe, except it only works on file entries in your vault.
+
+```
+$ passgo rmfile money/moneyfile.txt
 ```
 
 #### passgo integrity

--- a/edit/edit.go
+++ b/edit/edit.go
@@ -11,6 +11,8 @@ import (
 	"fmt"
 	"io/ioutil"
 	"log"
+	"os"
+	"path/filepath"
 
 	"golang.org/x/crypto/nacl/box"
 
@@ -20,12 +22,26 @@ import (
 )
 
 // Remove is used to remove a site entry from the password vault given a path.
-func Remove(path string) {
+func remove(path string, removeFile bool) {
 	vault := pio.GetVault()
 	pathIndex := -1
 	for jj, siteInfo := range vault {
 		if siteInfo.Name == path {
 			pathIndex = jj
+			if removeFile {
+				if !siteInfo.IsFile {
+					log.Fatalf("Attempting to remove a non-file entry. Use `passgo rm` not `passgo rmfile`")
+				}
+				encFileDir, err := pio.GetEncryptedFilesDir()
+				if err != nil {
+					log.Fatalf("Could not get encrypted file path for deleting: %s", err.Error())
+				}
+				fp := filepath.Join(encFileDir, siteInfo.FileName)
+				err = os.Remove(fp)
+				if err != nil {
+					log.Fatalf("Attempted to remove file but was unable to: %s", err.Error())
+				}
+			}
 			break
 		}
 	}
@@ -38,6 +54,16 @@ func Remove(path string) {
 		log.Fatalf("Could not update password vault: %s", err.Error())
 	}
 	sync.RemoveCommit(path)
+}
+
+// RemovePassword is called to remove a password entry.
+func RemovePassword(path string) {
+	remove(path, false)
+}
+
+// RemoveFile is called to remove a file and siteinfo entry.
+func RemoveFile(path string) {
+	remove(path, true)
 }
 
 // Edit is used to change the password of a site. New keys MUST be generated.

--- a/insert/insert.go
+++ b/insert/insert.go
@@ -20,8 +20,8 @@ const (
 	PassPrompt = "Enter password for %s"
 )
 
-// Insert is used to add a new entry to the vault.
-func Insert(name string) {
+// Password is used to add a new password entry to the vault.
+func Password(name string) {
 	var c pio.ConfigFile
 	pub, priv, err := box.GenerateKey(rand.Reader)
 	if err != nil {
@@ -64,4 +64,59 @@ func Insert(name string) {
 		log.Fatalf("Could not save site file: %s", err.Error())
 	}
 	sync.InsertCommit(name)
+}
+
+// File is used to add a new file entry to the vault.
+func File(path, filename string) {
+	var c pio.ConfigFile
+	pub, priv, err := box.GenerateKey(rand.Reader)
+	if err != nil {
+		log.Fatalf("Could not generate site key: %s", err.Error())
+	}
+
+	config, err := pio.GetConfigPath()
+	if err != nil {
+		log.Fatalf("Could not get config file name: %s", err.Error())
+	}
+
+	// Read the master public key.
+	configContents, err := ioutil.ReadFile(config)
+	if err != nil {
+		log.Fatalf("Could not get config file contents: %s", err.Error())
+	}
+
+	err = json.Unmarshal(configContents, &c)
+	if err != nil {
+		log.Fatalf("Could not unmarshal config file contents: %s", err.Error())
+	}
+
+	masterPub := c.MasterPubKey
+
+	fileBytes, err := ioutil.ReadFile(filename)
+	if err != nil {
+		log.Fatalf("Could not open and read file that is being encrypted: %s", err.Error())
+	}
+
+	fileSealed, err := pc.SealAsym([]byte(fileBytes), &masterPub, priv)
+	if err != nil {
+		log.Fatalf("Could not seal file bytes: %s", err.Error())
+	}
+
+	tokenFile, err := pc.GenHexString()
+	if err != nil {
+		log.Fatalf("Could not generate random string: %s", err.Error())
+	}
+
+	si := pio.SiteInfo{
+		PubKey:   *pub,
+		Name:     path,
+		IsFile:   true,
+		FileName: tokenFile,
+	}
+
+	err = si.AddFile(fileSealed, tokenFile)
+	if err != nil {
+		log.Fatalf("Could not save site file after file insert: %s", err.Error())
+	}
+	sync.InsertCommit(path)
 }

--- a/passgo.go
+++ b/passgo.go
@@ -27,8 +27,9 @@ var (
 	copyPass = flag.Bool("copy", false, "If true, copy password to clipboard instead of displaying it")
 
 	version = `======================================
-= passgo: v0.0                       =
-= The simple golang password manager =
+= passgo: v1.0                       =
+= The simple golang password and     =
+= file manager                       =
 =                                    =
 = Twiinsen Security                  =
 = evan@twiinsen.com                  =
@@ -59,8 +60,12 @@ var (
 		An alias for the find subcommand.
 	passgo remove site-path
 		Remove a site from the password vault by specifying the entire site-path.
+	passgo removefile site-path
+		Remove a file from the vault by specifying the entire file-path.
 	passgo rm site-path
 		An alias for remove.
+	passgo rmfile site-path
+		An alias for removefile.
 	passgo pull
 		Pull will perform a git pull and sync the changes in the remote git
 		repository with your local repo.
@@ -97,14 +102,11 @@ func main() {
 
 	// subArgs is used by subcommands to retreive only their args.
 	subArgs := flag.Args()[1:]
-
-	switch os.Args[1] {
+	switch flag.Args()[0] {
 	case "edit":
 		path := getSubArguments(subArgs, ALLARGS)
 		edit.Edit(path)
-	case "ls":
-		fallthrough
-	case "find":
+	case "ls", "find":
 		path := getSubArguments(subArgs, ALLARGS)
 		show.Find(path)
 	case "generate":
@@ -119,25 +121,20 @@ func main() {
 		initialize.Init()
 	case "insert":
 		pathName := getSubArguments(subArgs, ALLARGS)
-		insert.Insert(pathName)
+		insert.Password(pathName)
 	case "integrity":
 		pc.GetSitesIntegrity()
 		sync.Commit(sync.IntegrityCommit)
-	case "rm":
-		fallthrough
-	case "remove":
+	case "rm", "remove":
 		path := getSubArguments(subArgs, ALLARGS)
-		edit.Remove(path)
+		edit.RemovePassword(path)
 	case "rename":
 		path := getSubArguments(subArgs, ALLARGS)
 		edit.Rename(path)
-	case "help":
-		fallthrough
-	case "usage":
+	case "help", "usage":
 		printUsage()
 	case "version":
 		printVersion()
-	// These are used for git and syncing passwords.
 	case "pull":
 		sync.Pull()
 	case "push":
@@ -151,6 +148,19 @@ func main() {
 	case "show":
 		path := getSubArguments(flag.Args(), 1)
 		show.Site(path, *copyPass)
+	case "insertfile":
+		allArgs := getSubArguments(subArgs, ALLARGS)
+		argList := strings.Split(allArgs, " ")
+		if len(argList) != 2 {
+			printUsage()
+			log.Fatalln("Incorrect args.")
+		}
+		path := argList[0]
+		filename := argList[1]
+		insert.File(path, filename)
+	case "rmfile", "removefile":
+		path := getSubArguments(subArgs, ALLARGS)
+		edit.RemoveFile(path)
 	default:
 		log.Fatalf("%s\nInvalid Command %s", usage, os.Args[1])
 	}

--- a/pc/pc.go
+++ b/pc/pc.go
@@ -7,6 +7,7 @@ import (
 	"crypto/hmac"
 	"crypto/rand"
 	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"io/ioutil"
@@ -251,4 +252,14 @@ func GetSitesIntegrity() pio.ConfigFile {
 	vaultMac := mac.Sum(nil)
 	c.SiteHmac = vaultMac
 	return c
+}
+
+// GenHexString will generate a random 32 character hex string.
+func GenHexString() (string, error) {
+	var b [16]byte
+	_, err := rand.Read(b[:])
+	if err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b[:]), nil
 }


### PR DESCRIPTION
Create several new subcommands for encrypted files.
  - insertfile
  - rmfile
  - removefile

How encrypted files work.

Just likes passwords, except all the data is stored in a new subdirectory, ~/.passgo/files/.

