### PR TITLE
Adding multilines, imports, and a shows command line option that allows for entering partial hosts

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,7 @@
 language: go
 go: 
- - 1.5
- - 1.6 
- - 1.7 
  - 1.8 
+ - 1.9
  - tip
 env:
  - GO15VENDOREXPERIMENT=1

--- a/edit/edit.go
+++ b/edit/edit.go
@@ -72,10 +72,6 @@ func Edit(path string, multiline bool) {
 	vault := pio.GetVault()
 	for jj, siteInfo := range vault {
 		if siteInfo.Name == path {
-			newPass, err := pio.PromptPass(fmt.Sprintf("Enter new password for %s", path))
-			if err != nil {
-				log.Fatalf("Could not get new password for %s: %s", path, err)
-			}
 			var notes [][]byte
 			if siteInfo.NotesSealed != nil {
 				masterPrivKey := pc.GetMasterKey()
@@ -97,6 +93,10 @@ func Edit(path string, multiline bool) {
 						}
 					}
 				}
+			}
+			newPass, err := pio.PromptPass(fmt.Sprintf("Enter new password for %s", path))
+			if err != nil {
+				log.Fatalf("Could not get new password for %s: %s", path, err)
 			}
 			newSiteInfo := reencrypt(siteInfo, newPass, notes, multiline)
 			vault[jj] = newSiteInfo

--- a/edit/edit.go
+++ b/edit/edit.go
@@ -114,9 +114,10 @@ func Rename(path string) {
 				log.Fatalf("Could not get new site name from user: %s", err.Error())
 			}
 			vault[jj] = pio.SiteInfo{
-				PubKey:     siteInfo.PubKey,
-				PassSealed: siteInfo.PassSealed,
-				Name:       newName,
+				PubKey:      siteInfo.PubKey,
+				PassSealed:  siteInfo.PassSealed,
+				NotesSealed: siteInfo.NotesSealed,
+				Name:        newName,
 			}
 			err = pio.UpdateVault(vault)
 			if err != nil {

--- a/edit/edit.go
+++ b/edit/edit.go
@@ -89,7 +89,7 @@ func Edit(path string, multiline bool) {
 						} else {
 							s, err := pio.Prompt(fmt.Sprintf("Keep the following note '%s' (Y/n)? ", note))
 							if err != nil {
-								log.Fatalf("Could not get user response: %s", err)
+								log.Fatalf("Could not get user response: %s", err.Error())
 							}
 							if s == "" || s == "y" || s == "Y" {
 								notes = append(notes, note)
@@ -102,7 +102,7 @@ func Edit(path string, multiline bool) {
 			vault[jj] = newSiteInfo
 			err = pio.UpdateVault(vault)
 			if err != nil {
-				log.Fatalf("Could not edit %s: %s", path, err)
+				log.Fatalf("Could not edit %s: %s", path, err.Error())
 			}
 			sync.RegenerateCommit(path)
 		}

--- a/insert/insert.go
+++ b/insert/insert.go
@@ -21,7 +21,7 @@ const (
 )
 
 // Password is used to add a new password entry to the vault.
-func Password(name string) {
+func Password(name string, multiline bool) {
 	var c pio.ConfigFile
 	pub, priv, err := box.GenerateKey(rand.Reader)
 	if err != nil {
@@ -50,13 +50,17 @@ func Password(name string) {
 	if err != nil {
 		log.Fatalf("Could not get password for site: %s", err.Error())
 	}
-
 	passSealed, err := pc.SealAsym([]byte(sitePass), &masterPub, priv)
 
+	var notesSealed [][]byte
+	if multiline {
+		notesSealed = pc.GetMultiline(masterPub, priv)
+	}
 	si := pio.SiteInfo{
-		PubKey:     *pub,
-		Name:       name,
-		PassSealed: passSealed,
+		PubKey:      *pub,
+		Name:        name,
+		PassSealed:  passSealed,
+		NotesSealed: notesSealed,
 	}
 
 	err = si.AddSite()

--- a/passgo.go
+++ b/passgo.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ejcx/passgo/initialize"
 	"github.com/ejcx/passgo/insert"
 	"github.com/ejcx/passgo/pc"
+	"github.com/ejcx/passgo/pcsv"
 	"github.com/ejcx/passgo/pio"
 	"github.com/ejcx/passgo/show"
 	"github.com/ejcx/passgo/sync"
@@ -42,6 +43,9 @@ var (
 		Print the password of a passgo entry.
 	passgo init
 		Initialize the .passgo directory, and generate your secret keys.
+	passgo import csv-file
+		Import a csv file.  The first line must be a comma separated list where
+		the columns labeled 'Password' and 'Hostname' (or 'Name') exist.
 	passgo insert site-path
 		Add a site to your password store. This site can optionally be a part
 		of a group by prepending a group name and slash to the site name.
@@ -118,6 +122,9 @@ func main() {
 	// subArgs is used by subcommands to retreive only their args.
 	subArgs, multiline := SubArgs(flag.Args())
 	switch flag.Args()[0] {
+	case "import":
+		path := getSubArguments(subArgs, ALLARGS)
+		pcsv.Import(path)
 	case "edit":
 		path := getSubArguments(subArgs, ALLARGS)
 		edit.Edit(path, multiline)

--- a/passgo.go
+++ b/passgo.go
@@ -120,7 +120,7 @@ func main() {
 	switch flag.Args()[0] {
 	case "edit":
 		path := getSubArguments(subArgs, ALLARGS)
-		edit.Edit(path)
+		edit.Edit(path, multiline)
 	case "ls", "find":
 		path := getSubArguments(subArgs, ALLARGS)
 		show.Find(path)

--- a/passgo.go
+++ b/passgo.go
@@ -91,6 +91,18 @@ var (
 `
 )
 
+func SubArgs(args []string) (subArgs []string, multiline bool) {
+	subArgs = args[1:]
+	for jj, arg := range subArgs {
+		if arg == "-m" || arg == "--multi" {
+			multiline = true
+			subArgs = append(subArgs[:jj], subArgs[jj+1:]...)
+			jj--
+		}
+	}
+	return subArgs, multiline
+}
+
 func main() {
 	// Check to see if this user is under attack.
 	pio.CheckAttackFile()
@@ -104,7 +116,7 @@ func main() {
 	}
 
 	// subArgs is used by subcommands to retreive only their args.
-	subArgs := flag.Args()[1:]
+	subArgs, multiline := SubArgs(flag.Args())
 	switch flag.Args()[0] {
 	case "edit":
 		path := getSubArguments(subArgs, ALLARGS)
@@ -124,7 +136,7 @@ func main() {
 		initialize.Init()
 	case "insert":
 		pathName := getSubArguments(subArgs, ALLARGS)
-		insert.Password(pathName)
+		insert.Password(pathName, multiline)
 	case "integrity":
 		pc.GetSitesIntegrity()
 		sync.Commit(sync.IntegrityCommit)

--- a/passgo.go
+++ b/passgo.go
@@ -41,6 +41,9 @@ var (
 		Print the contents of the vault.
 	passgo show site-path
 		Print the password of a passgo entry.
+	passgo shows site-path-substring
+		Short for "show substringed (site)".
+		Print the password of the first passgo entry to contain the given substring.
 	passgo init
 		Initialize the .passgo directory, and generate your secret keys.
 	passgo import csv-file
@@ -170,6 +173,9 @@ func main() {
 	case "show":
 		path := getSubArguments(flag.Args(), 1)
 		show.Site(path, *copyPass)
+	case "shows":
+		path := getSubArguments(flag.Args(), 1)
+		show.SubMatch(path, *copyPass)
 	case "insertfile":
 		allArgs := getSubArguments(subArgs, ALLARGS)
 		argList := strings.Split(allArgs, " ")

--- a/passgo_test.go
+++ b/passgo_test.go
@@ -1,0 +1,45 @@
+package main
+
+import (
+	"testing"
+)
+
+func StandardArgs(t *testing.T, args []string) {
+	if len(args) != 2 {
+		t.Fatal("Args size incorrect")
+	}
+	if args[0] != "insert" {
+		t.Fatal("Expecting command insert")
+	}
+	if args[1] != "site-path" {
+		t.Fatal("Expecting site path")
+	}
+}
+
+func TestNotMultiline(t *testing.T) {
+	var multiline bool
+	args := []string{"passgo", "insert", "site-path"}
+	args, multiline = SubArgs(args)
+	if multiline {
+		t.Fatal("Not a multiline command")
+	}
+	StandardArgs(t, args)
+}
+
+func TestMultiline(t *testing.T) {
+	var multiline bool
+	args := []string{"passgo", "insert", "-m", "site-path"}
+	args, multiline = SubArgs(args)
+	if !multiline {
+		t.Fatal("Expecting multiline command")
+	}
+	StandardArgs(t, args)
+
+	multiline = false
+	args = []string{"passgo", "insert", "--multi", "site-path"}
+	args, multiline = SubArgs(args)
+	if !multiline {
+		t.Fatal("Expecting multiline command")
+	}
+	StandardArgs(t, args)
+}

--- a/pc/pc.go
+++ b/pc/pc.go
@@ -63,6 +63,25 @@ type PasswordSpecs struct {
 	NeedsDigit  bool
 }
 
+func GetMultiline(masterPub [32]byte, priv *[32]byte) (notesSealed [][]byte) {
+	notesSealed = make([][]byte, 0)
+	for {
+		note, err := pio.Prompt("Enter note: ")
+		if err != nil {
+			log.Fatalf("Could not get note: %s", err.Error())
+		}
+		if note == "" {
+			break
+		}
+		noteSealed, err := SealAsym([]byte(note), &masterPub, priv)
+		if err != nil {
+			log.Fatalf("Could not get note: %s", err.Error())
+		}
+		notesSealed = append(notesSealed, noteSealed)
+	}
+	return notesSealed
+}
+
 // Seal wraps that AEAD interface secretbox Seal and safely
 // generates a random nonce for developers. This change to
 // seal eliminates the risk of programmers reusing nonces.

--- a/pcsv/pcsv.go
+++ b/pcsv/pcsv.go
@@ -1,0 +1,109 @@
+package pcsv
+
+import (
+	"bytes"
+	"crypto/rand"
+	"encoding/csv"
+	"encoding/json"
+	"io/ioutil"
+	"log"
+	"strings"
+
+	"github.com/ejcx/passgo/pc"
+	"github.com/ejcx/passgo/pio"
+	"github.com/ejcx/passgo/sync"
+	"golang.org/x/crypto/nacl/box"
+)
+
+func Import(path string) {
+	b, err := ioutil.ReadFile(path)
+	if err != nil {
+		log.Fatalf("Failed to read file %s: %s", path, err.Error())
+	}
+	r := csv.NewReader(bytes.NewReader(b))
+	records, err := r.ReadAll()
+	if err != nil {
+		log.Fatalf("Csv failed to read bytes %s", err.Error())
+	}
+	nameAt, hostAt, passAt := -1, -1, -1
+	columns := []string{}
+	for jj, record := range records {
+		if jj == 0 {
+			for kk, col := range record {
+				if strings.ToLower(col) == "password" {
+					passAt = kk
+				}
+				if strings.ToLower(col) == "hostname" {
+					hostAt = kk
+				}
+				if strings.ToLower(col) == "name" {
+					nameAt = kk
+				}
+			}
+			if passAt == -1 || (hostAt == -1 && nameAt == -1) {
+				log.Fatal("The password and hostname/name columns are required.")
+			}
+			columns = record
+		} else {
+			ImportMultiEntry(columns, record, passAt, hostAt, nameAt)
+		}
+	}
+}
+
+func ImportMultiEntry(colNames []string, record []string, passAt, hostAt, nameAt int) {
+	var c pio.ConfigFile
+	pub, priv, err := box.GenerateKey(rand.Reader)
+	if err != nil {
+		log.Fatalf("Could not generate site key: %s", err.Error())
+	}
+
+	config, err := pio.GetConfigPath()
+	if err != nil {
+		log.Fatalf("Could not get config file name: %s", err.Error())
+	}
+
+	// Read the master public key.
+	configContents, err := ioutil.ReadFile(config)
+	if err != nil {
+		log.Fatalf("Could not get config file contents: %s", err.Error())
+	}
+
+	err = json.Unmarshal(configContents, &c)
+	if err != nil {
+		log.Fatalf("Could not unmarshal config file contents: %s", err.Error())
+	}
+
+	masterPub := c.MasterPubKey
+
+	passSealed, err := pc.SealAsym([]byte(record[passAt]), &masterPub, priv)
+
+	var notesSealed [][]byte
+	if len(record) > 2 {
+		for jj, column := range record {
+			if jj != hostAt && jj != passAt {
+				noteSealed, err := pc.SealAsym([]byte(colNames[jj]+": "+column), &masterPub, priv)
+				if err != nil {
+					log.Fatalf("Could not seal note: %s", err.Error())
+				}
+				notesSealed = append(notesSealed, noteSealed)
+			}
+		}
+	}
+	si := pio.SiteInfo{
+		PubKey:      *pub,
+		Name:        record[hostAt],
+		PassSealed:  passSealed,
+		NotesSealed: notesSealed,
+	}
+
+	err = si.AddSite()
+	if err != nil {
+		si.Name = record[nameAt]
+		err = si.AddSite()
+		if err != nil {
+			log.Printf("Could not save site file '%s': %s", strings.Join(record, " "), err.Error())
+			return
+		}
+	}
+	sync.InsertCommit(si.Name)
+}

--- a/pio/pio.go
+++ b/pio/pio.go
@@ -51,11 +51,12 @@ type ConfigFile struct {
 
 // SiteInfo represents a single saved password entry.
 type SiteInfo struct {
-	PubKey     [32]byte
-	PassSealed []byte
-	Name       string
-	FileName   string
-	IsFile     bool
+	PubKey      [32]byte
+	PassSealed  []byte
+	NotesSealed [][]byte
+	Name        string
+	FileName    string
+	IsFile      bool
 }
 
 // SiteFile represents the entire passgo password store.

--- a/show/show.go
+++ b/show/show.go
@@ -32,6 +32,8 @@ const (
 	// Search indicates that SearchSites should return all sites found that
 	// match that contain the searchFor string
 	Search
+	// Return the first matching site with a given prefixed value
+	ShowMatch
 )
 
 func init() {
@@ -65,6 +67,18 @@ func Find(frag string) {
 // Site will print out the password of the site that matches path
 func Site(path string, copyPassword bool) {
 	allSites, allErrors := SearchAll(One, path)
+	if len(allSites) == 0 {
+		fmt.Printf("Site with path %s not found", path)
+		return
+	}
+	masterPrivKey := pc.GetMasterKey()
+	showPassword(allSites, masterPrivKey, copyPassword)
+	handleErrors(allErrors)
+}
+
+// SubMatch will print out the password of the site that contains the path
+func SubMatch(path string, copyPassword bool) {
+	allSites, allErrors := SearchAll(ShowMatch, path)
 	if len(allSites) == 0 {
 		fmt.Printf("Site with path %s not found", path)
 		return
@@ -222,6 +236,14 @@ func SearchAll(st searchType, searchFor string) (allSites map[string][]pio.SiteI
 		}
 		if st == One {
 			if name == searchFor || fmt.Sprintf("%s/%s", group, name) == searchFor {
+				return map[string][]pio.SiteInfo{
+					group: []pio.SiteInfo{
+						si,
+					},
+				}, allErrors
+			}
+		} else if st == ShowMatch {
+			if strings.Contains(name, searchFor) {
 				return map[string][]pio.SiteInfo{
 					group: []pio.SiteInfo{
 						si,

--- a/sync/sync.go
+++ b/sync/sync.go
@@ -213,7 +213,7 @@ func Commit(msg string) {
 	if err != nil {
 		log.Fatalf("Could not change to pass directory: %s", err)
 	}
-	_, err = exec.Command("git", "add", "-u").Output()
+	_, err = exec.Command("git", "add", "-A").Output()
 	if err != nil {
 		log.Fatalf("Could not add files for commit: %s", err)
 	}


### PR DESCRIPTION
Treats additional lines as "notes" that are simply a separate array of values.  

The editing action is a bit more complex due to needing to re-encrypt existing notes.  When notes exist, a prompt for the master password is required.  A multiline edit allows the user to remove existing notes as well as add notes whereas a typical edit assumes retention.