### PR TITLE
sync: revert to -u parameter on git push, use -A on git add

### DIFF
--- a/sync/sync.go
+++ b/sync/sync.go
@@ -90,7 +90,7 @@ func Push() {
 		log.Fatalf("Could not save config file with hmac: %s", err)
 	}
 	Commit("Update integrity hash")
-	_, err = exec.Command("git", "push", "-A", "pass-origin", "master").Output()
+	_, err = exec.Command("git", "push", "-u", "pass-origin", "master").Output()
 	if err != nil {
 		log.Fatalf("Could not push changes: %s", err.Error())
 	}
@@ -213,7 +213,7 @@ func Commit(msg string) {
 	if err != nil {
 		log.Fatalf("Could not change to pass directory: %s", err)
 	}
-	_, err = exec.Command("git", "add", "-u").Output()
+	_, err = exec.Command("git", "add", "-A").Output()
 	if err != nil {
 		log.Fatalf("Could not add files for commit: %s", err)
 	}


### PR DESCRIPTION
This change is a fixup for PR #50 that applied the s/-u/-A/ parameter
change to the wrong git command. It should've been applied to `git add`
in `Commit` function, not `git push` in `Push` function.

Updates #49.