### PR TITLE
Fix passgo generate to generate proper passwords

### DIFF
--- a/pc/pc.go
+++ b/pc/pc.go
@@ -10,6 +10,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"log"
 
@@ -17,6 +18,10 @@ import (
 	"golang.org/x/crypto/nacl/box"
 	"golang.org/x/crypto/nacl/secretbox"
 	"golang.org/x/crypto/scrypt"
+)
+
+const (
+	maxPwLength = 65535
 )
 
 var (
@@ -151,11 +156,6 @@ func GetMasterKey() (masterPrivKey [32]byte) {
 	return
 }
 
-// Satisfied will determine if a PasswordSpecs type indicates it no longer
-// needs any more specs.
-func (s *PasswordSpecs) Satisfied() bool {
-	return !s.NeedsDigit && !s.NeedsUpper && !s.NeedsLower && !s.NeedsSymbol
-}
 func checkBound(letter byte, lowerBound, upperBound int) bool {
 	if int(letter) >= lowerBound && int(letter) <= upperBound {
 		return true
@@ -178,16 +178,25 @@ func isASCIISymbol(letter byte) bool {
 	grp4 := checkBound(letter, SymbolGrp4LowerBound, SymbolGrp4UpperBound)
 	return grp1 || grp2 || grp3 || grp4
 }
-func updateSpec(specs *PasswordSpecs, letter byte) {
-	if isASCIIDigit(letter) {
-		specs.NeedsDigit = false
-	} else if isASCIIUpper(letter) {
-		specs.NeedsUpper = false
-	} else if isASCIILower(letter) {
-		specs.NeedsLower = false
-	} else if isASCIISymbol(letter) {
-		specs.NeedsSymbol = false
+
+func passwordExpectationsPossible(specs *PasswordSpecs, passlen int) bool {
+	minLength := 0
+	if specs.NeedsUpper {
+		minLength++
 	}
+	if specs.NeedsLower {
+		minLength++
+	}
+	if specs.NeedsSymbol {
+		minLength++
+	}
+	if specs.NeedsDigit {
+		minLength++
+	}
+	if passlen < minLength {
+		return false
+	}
+	return true
 }
 
 // GeneratePassword is used to generate a password like string securely.
@@ -201,31 +210,61 @@ func updateSpec(specs *PasswordSpecs, letter byte) {
 // to  read chunks of randomness until it has found a password that
 // meets the specifications of the PasswordSpec passed in to the func.
 func GeneratePassword(specs *PasswordSpecs, passlen int) (pass string, err error) {
-	var letters [2048]byte
+	var (
+		letters [65535]byte
+	)
+	if !passwordExpectationsPossible(specs, passlen) {
+		err = errors.New("Invalid password specs and length passed in to generate password. Try generating a longer password")
+		return
+	}
+	if passlen > maxPwLength {
+		err = fmt.Errorf("Max password length is %d. Generate a shorter password", maxPwLength)
+		return
+	}
 	for {
-		if passlen <= len(pass) {
-			if specs.Satisfied() {
-				return pass, nil
-			}
-		}
+		pass = ""
 		_, err = rand.Read(letters[:])
 		if err != nil {
 			return
 		}
 		for _, letter := range letters {
-			if passlen <= len(pass) {
-				if specs.Satisfied() {
-					return pass, nil
-				}
-			}
 			// Check to make sure that the letter is inside
 			// the range of printable characters
 			if letter > 32 && letter < 127 {
 				pass += string(letter)
 			}
-			updateSpec(specs, letter)
+			// If it doesn't meet the specs, but we verified earlier that it is
+			// possible to meet the pw expectations, just try again.
+			if passlen == len(pass) {
+				if specs.MeetsSpecs(pass) {
+					return
+				}
+			}
 		}
 	}
+}
+
+func (specs *PasswordSpecs) MeetsSpecs(pass string) bool {
+	var (
+		needsUpper  = specs.NeedsUpper
+		needsLower  = specs.NeedsLower
+		needsSymbol = specs.NeedsSymbol
+		needsDigit  = specs.NeedsDigit
+	)
+	for i := 0; i < len(pass); i++ {
+		if isASCIIDigit(pass[i]) {
+			needsDigit = false
+		} else if isASCIIUpper(pass[i]) {
+			needsUpper = false
+		} else if isASCIILower(pass[i]) {
+			needsLower = false
+		} else if isASCIISymbol(pass[i]) {
+			needsSymbol = false
+		}
+	}
+	// Return true if it doesn't need any uppers, it doesn't need any lowers
+	// it doesn't need any symbols, and it doesn't need any digits.
+	return !needsUpper && !needsLower && !needsSymbol && !needsDigit
 }
 
 // GetSitesIntegrity is used to update the sites vault integrity file.

--- a/pc/pc_test.go
+++ b/pc/pc_test.go
@@ -19,9 +19,38 @@ func TestGenHexString(t *testing.T) {
 func TestGeneratePassword(t *testing.T) {
 	pass, err := GeneratePassword(&PasswordSpecs{}, 20)
 	if err != nil {
-		t.Errorf("Could not decode hex string: %s", err)
+		t.Fatalf("Could not generate password: %s", err)
 	}
 	if len(pass) == 0 {
-		t.Error("Bad length of password. Should never be 0")
+		t.Fatalf("Bad length of password. Should never be 0")
+	}
+}
+
+func TestGenerateImpossiblePassword(t *testing.T) {
+	ps := &PasswordSpecs{
+		NeedsUpper:  true,
+		NeedsLower:  true,
+		NeedsSymbol: true,
+		NeedsDigit:  true,
+	}
+	_, err := GeneratePassword(ps, 3)
+	if err == nil {
+		t.Fatalf("Impossible password request did not throw an error")
+	}
+}
+
+func TestGenerateShortPassword(t *testing.T) {
+	ps := &PasswordSpecs{
+		NeedsUpper:  true,
+		NeedsLower:  true,
+		NeedsSymbol: true,
+		NeedsDigit:  true,
+	}
+	pass, err := GeneratePassword(ps, 4)
+	if err != nil {
+		t.Fatalf("Could not generate password: %s", err)
+	}
+	if len(pass) != 4 {
+		t.Fatalf("Bad length of password. Should be 4")
 	}
 }


### PR DESCRIPTION
There was a problem with `passgo generate` for a long time. It just so happened
that if you requested to generate a very short password, but a very secure pass
then the program would return a password that was much longer than expected.

The reason for this was the program prioritized just getting you a strong
password, rather than getting you a password with your exact length reqs.

This fixes that issue by:
    - Checks if you are requesting an impossible to satisfy password.
    - Short possible to satisfy situations, continue to retry generation
    - Stop returning passwords longer than the user asks for.

Hopefully this makes things work a little better.