### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/pio/pio.go
+++ b/pio/pio.go
@@ -157,7 +157,7 @@ func GetConfigPath() (p string, err error) {
 	return
 }
 
-// GetFilesDir is used to get the directory that we store
+// GetEncryptedFilesDir is used to get the directory that we store
 // encrypted files in.
 func GetEncryptedFilesDir() (p string, err error) {
 	d, err := GetPassDir()


### PR DESCRIPTION
Every exported function in a program should have a doc comment. The first sentence should be a summary that starts with the name being declared.
From [effective go](https://golang.org/doc/effective_go.html#commentary).

I generated this with [CodeLingo](https://codelingo.io) and I'm keen to get some feedback, *but this is automated so feel free to close it and just say "opt out" to opt out of future CodeLingo outreach PRs.*