### PR TITLE
fix various issues

### DIFF
--- a/insert/insert.go
+++ b/insert/insert.go
@@ -51,6 +51,9 @@ func Password(name string) {
 	}
 
 	passSealed, err := pc.SealAsym([]byte(sitePass), &masterPub, priv)
+	if err != nil {
+		log.Fatalf("Could not seal new site password: %s", err.Error())
+	}
 
 	si := pio.SiteInfo{
 		PubKey:     *pub,

--- a/passgo.go
+++ b/passgo.go
@@ -155,6 +155,7 @@ func init() {
 	RootCmd.AddCommand(initCmd)
 	RootCmd.AddCommand(insertCmd)
 	RootCmd.AddCommand(removeCmd)
+	RootCmd.AddCommand(editCmd)
 	RootCmd.AddCommand(renameCmd)
 	RootCmd.AddCommand(showCmd)
 	RootCmd.AddCommand(versionCmd)

--- a/pio/pio.go
+++ b/pio/pio.go
@@ -245,10 +245,10 @@ func GetSiteFileBytes() (b []byte) {
 		log.Fatalf("Could not get pass dir: %s", err.Error())
 	}
 	f, err := os.OpenFile(si, os.O_RDWR, 0600)
-	defer f.Close()
 	if err != nil {
 		log.Fatalf("Could not open site file: %s", err.Error())
 	}
+	defer f.Close()
 	b, err = ioutil.ReadAll(f)
 	if err != nil {
 		log.Fatalf("Could not read site file: %s", err.Error())


### PR DESCRIPTION
This PR includes 3 commits, each fixing a minor problem.

These were found via @dominikh's [staticcheck](https://staticcheck.io/) tool.

```
insert/insert.go:53:14: this value of err is never used (SA4006)
passgo.go:129:2: var editCmd is unused (U1000)
pio/pio.go:248:2: should check returned error before deferring f.Close() (SA5001)
```