### PR TITLE
Redirect enter password printout to stderr

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,9 @@ The `PASSGODIR` environment variable specifies the directory that your vault is 
 
 I store my vault in the default location `~/.passgo`. All subcommands will respect this environment variable, including `init`
 
+Possible to store master password as a config file on local machine.
+Only do this if you have a secure local machine, see "Threat model" SECTION below.
+File to store password: `~/.config/passgo/passgo.pass`
 
 ## COMMANDS
 
@@ -64,10 +67,10 @@ By default, passgo will create your password vault in the `.passgo` directory wi
 ### Inserting a password
 ```
 $ passgo insert money/mint.com
-Enter password for money/mint.com: 
+Enter password for money/mint.com:
 ```
 
-Inserting a password in to your vault is easy. If you wish to group multiple entries together, it can be accomplished by prepending a group name followed by a slash to the pass-name. 
+Inserting a password in to your vault is easy. If you wish to group multiple entries together, it can be accomplished by prepending a group name followed by a slash to the pass-name.
 
 Here we are adding mint.com to the password store within the money group.
 
@@ -77,7 +80,7 @@ Here we are adding mint.com to the password store within the money group.
 $ passgo insert money/budget.csv budget.csv
 ```
 
-Adding a file works almost the same as insert. Instead it has an extra argument. The file that you want to add to your vault is the final argument. 
+Adding a file works almost the same as insert. Instead it has an extra argument. The file that you want to add to your vault is the final argument.
 
 
 ### Retrieving a password
@@ -89,7 +92,6 @@ dolladollabills$$1
 
 Show is used to display a password in standard out.
 
-	
 ### Rename a password
 ```
 $ passgo rename mney/mint.com

--- a/pc/pc.go
+++ b/pc/pc.go
@@ -123,10 +123,16 @@ func Scrypt(pass, salt []byte) (key [32]byte, err error) {
 // GetMasterKey is used to prompt user's for their password, read the
 // user's passgo config file and decrypt the master private key.
 func GetMasterKey() (masterPrivKey [32]byte) {
-	pass, err := pio.PromptPass(pio.MasterPassPrompt)
+	// See if we saved password it locally
+	pass, err := pio.GetPassFromFile()
 	if err != nil {
-		log.Fatalf("Could not get master password: %s", err.Error())
+		// Ask user for password
+		pass, err = pio.PromptPass(pio.MasterPassPrompt)
+		if err != nil {
+			log.Fatalf("Could not get master password: %s", err.Error())
+		}
 	}
+
 	c, err := pio.GetConfigPath()
 	if err != nil {
 		log.Fatalf("Could not get config file: %s", err.Error())

--- a/pio/pio.go
+++ b/pio/pio.go
@@ -11,6 +11,7 @@ import (
 	"os/signal"
 	"os/user"
 	"path/filepath"
+	"strings"
 
 	"github.com/atotto/clipboard"
 
@@ -305,6 +306,18 @@ func ReadConfig() (c ConfigFile, err error) {
 	}
 	err = json.Unmarshal(configBytes, &c)
 	return
+}
+
+// GetPassFromFile will get users password from ~/.config/passgo/passgo.pass if present.
+func GetPassFromFile() (pass string, err error) {
+	passwordFile := os.Getenv("HOME") + "/.config/passgo/passgo.pass"
+	content, err := ioutil.ReadFile(passwordFile)
+	if err != nil {
+		return "", err
+	} else {
+		fmt.Fprintf(os.Stderr, "Found and using password file, %s\n", passwordFile)
+		return strings.TrimSuffix(string(content), "\n"), nil
+	}
 }
 
 // PromptPass will prompt user's for a password by terminal.

--- a/pio/pio.go
+++ b/pio/pio.go
@@ -327,9 +327,9 @@ func PromptPass(prompt string) (pass string, err error) {
 		}
 	}()
 
-	fmt.Printf("%s: ", prompt)
+	fmt.Fprintf(os.Stderr, "%s: ", prompt)
 	passBytes, err := terminal.ReadPassword(fd)
-	fmt.Println("")
+	fmt.Fprintln(os.Stderr, "")
 	return string(passBytes), err
 }
 

--- a/show/show.go
+++ b/show/show.go
@@ -117,7 +117,7 @@ func showPassword(allSites map[string][]pio.SiteInfo, masterPrivKey [32]byte, co
 			if copyPassword {
 				pio.ToClipboard(string(unsealed))
 			} else {
-				fmt.Println(string(unsealed))
+				fmt.Print(string(unsealed))
 			}
 		}
 	}


### PR DESCRIPTION
Today "Enter master password:" string end up in file if you redirect stdout to file.
Print string to stderr instead. 