### PR TITLE
Add a plain listing mode for sites

### DIFF
--- a/passgo.go
+++ b/passgo.go
@@ -15,8 +15,8 @@ import (
 )
 
 var (
-	copyPass bool
-	RootCmd  = &cobra.Command{
+	copyPass, listPlain bool
+	RootCmd             = &cobra.Command{
 		Use:   "passgo",
 		Short: "Print the contents of the vault.",
 		Long: `Print the contents of the vault. If you have
@@ -25,7 +25,7 @@ the init subcommand in order to create your passgo
 directory, and initialize your cryptographic keys.`,
 		Run: func(cmd *cobra.Command, args []string) {
 			if exists, _ := pio.PassFileDirExists(); exists {
-				show.ListAll()
+				show.ListAll(listPlain)
 			} else {
 				cmd.Help()
 			}
@@ -113,7 +113,7 @@ one group or all sites that contain a certain word in the group or name`,
 		Args: cobra.ExactArgs(1),
 		Run: func(cmd *cobra.Command, args []string) {
 			path := args[0]
-			show.Find(path)
+			show.Find(path, listPlain)
 		},
 	}
 	renameCmd = &cobra.Command{
@@ -152,6 +152,8 @@ one group or all sites that contain a certain word in the group or name`,
 
 func init() {
 	showCmd.PersistentFlags().BoolVarP(&copyPass, "copy", "c", false, "Copy your password to the clipboard")
+	RootCmd.PersistentFlags().BoolVarP(&listPlain, "plain", "p", false, "List sites in plain format")
+	findCmd.PersistentFlags().BoolVarP(&listPlain, "plain", "p", false, "List sites in plain format")
 	RootCmd.AddCommand(findCmd)
 	RootCmd.AddCommand(generateCmd)
 	RootCmd.AddCommand(initCmd)

--- a/show/show.go
+++ b/show/show.go
@@ -56,9 +56,9 @@ func handleErrors(allErrors []error) {
 }
 
 // Find will search the vault for all occurences of frag in the site name.
-func Find(frag string) {
+func Find(frag string, listPlain bool) {
 	allSites, allErrors := SearchAll(Search, frag)
-	showResults(allSites)
+	showResults(allSites, listPlain)
 	handleErrors(allErrors)
 }
 
@@ -75,9 +75,9 @@ func Site(path string, copyPassword bool) {
 }
 
 // ListAll will print out all contents of the vault.
-func ListAll() {
+func ListAll(listPlain bool) {
 	allSites, allErrors := SearchAll(All, "")
-	showResults(allSites)
+	showResults(allSites, listPlain)
 	handleErrors(allErrors)
 }
 
@@ -123,7 +123,23 @@ func showPassword(allSites map[string][]pio.SiteInfo, masterPrivKey [32]byte, co
 	}
 }
 
-func showResults(allSites map[string][]pio.SiteInfo) {
+func showResults(allSites map[string][]pio.SiteInfo, listPlain bool) {
+	if listPlain {
+		showResultsPlain(allSites)
+	} else {
+		showResultsDefault(allSites)
+	}
+}
+
+func showResultsPlain(allSites map[string][]pio.SiteInfo) {
+	for group, siteList := range allSites {
+		for _, site := range siteList {
+			fmt.Printf("%s/%s\n", group, site.Name)
+		}
+	}
+}
+
+func showResultsDefault(allSites map[string][]pio.SiteInfo) {
 	fmt.Println(".")
 	counter := 1
 	for group, siteList := range allSites {


### PR DESCRIPTION
In "plain" mode, each group/site is printed in full, one per line. This
makes listings a little easier to pipe into other commands.

Example use: passgo show -c $(passgo -p | fzf)